### PR TITLE
Import export methods

### DIFF
--- a/index.php
+++ b/index.php
@@ -240,7 +240,7 @@ class Movies implements Iterator, Countable, ArrayAccess {
   public static function import($jsonDatas, $logged = false){
     global $_CONFIG;
   
-    $datas = json_decode($jsonDatas);
+    $datas = json_decode($jsonDatas, true);
     if(!isset($datas['datas']) || !isset($datas['images'])){
       return NULL;
     }


### PR DESCRIPTION
Ajoute les méthodes d'import et d'export des films.

Les données sont exportées et importées en JSON, il est possible de choisir les données à exporter : 
Il est possible de choisir d'exporter les données privées (Vue, possédé, note) ou pas et de choisir d'exporter les images (en base64 dans le JSON) ou pas.
Par défaut l'ensemble des films sont exportés mais il est possible de sélectionner que certains ids.

L'importation se fait avec les donnés JSON brutes.
Les données sont automatiquement vérifiées, les ids réordonnées pour éviter toute collision avec un film en cours d'importation ou déjà présent. Les images sont reconstruites et les liens vers celles-ci sont mis à jour dans les films importés en cas de succès.

En cas d'erreur lors de l'importation d'un film, celui ci n'est pas importé et on tente le suivant.
